### PR TITLE
New endpoints, quicker responses & more

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,32 +8,10 @@
 
 * Make sure that python and virual environment is installed.
 
-* Create a new virtual environment
-
-```python
-# one time
-virtualenv -p $(which python3) pyenv
-
-# everytime you want to run the server
-source pyenv/bin/activate
-```
-
-* Now install the requirements
+* To start the server run the following command
 
 ```
-pip install -r requirements.txt
-```
-
-* If you are installing playwright for the first time, it will ask you to run this command for one time only.
-
-```
-playwright install
-```
-
-* Now run the server
-
-```
-python server.py
+chmod +x run.sh && ./run.sh
 ```
 
 * The server runs at port `5001`. If you want to change, you can change it in server.py
@@ -41,10 +19,19 @@ python server.py
 
 # Api Documentation
 
-* There is a single end point only. It is available at `/chat`
-
+* GET /chat >>> Send a message and recive the response
 ```sh
-curl -XGET http://localhost:5001/chat?q=Write%20a%20python%20program%20to%20reverse%20a%20list
+curl -X GET http://localhost:5001/chat?q=Write%20a%20python%20program%20to%20reverse%20a%20list
+```
+
+* POST /regenerate >>> Regenerate the last response
+```sh
+curl -X POST http://localhost:5001/regenerate
+```
+
+* POST /reset >>> Resets the chat thread. 
+* ```sh
+curl -X POST http://localhost:5001/reset
 ```
 
 # Credit

--- a/server.py
+++ b/server.py
@@ -1,10 +1,7 @@
 """Make some requests to OpenAI's chatbot"""
 
 import time
-import os
 import flask
-
-from flask import g
 
 from playwright.sync_api import sync_playwright
 
@@ -24,6 +21,10 @@ def is_logged_in():
     # See if we have a textarea with data-id="root"
     return get_input_box() is not None
 
+def is_loading_response() -> bool:
+    """See if the send button is diabled, if it does, we're not loading"""
+    return not PAGE.query_selector("button[class*='PromptTextarea__PositionSubmit']").is_enabled()
+
 def send_message(message):
     # Send the message
     box = get_input_box()
@@ -33,20 +34,49 @@ def send_message(message):
 
 def get_last_message():
     """Get the latest message"""
+    while is_loading_response():
+        time.sleep(0.25)
     page_elements = PAGE.query_selector_all("div[class*='ConversationItem__Message']")
     last_element = page_elements[-1]
     return last_element.inner_text()
 
-@APP.route("/chat", methods=["GET"])
+def regenerate_response():
+    """Clicks on the Try again button. 
+    Returns None if there is no button"""
+    try_again_button = PAGE.query_selector("button:has-text('Try again')")
+    if try_again_button is not None:
+        try_again_button.click()
+    return try_again_button
+
+def get_reset_button():
+    """Returns the reset thread button (it is an a tag not a button)"""
+    return PAGE.query_selector("a:has-text('Reset thread')")
+
+@APP.route("/chat", methods=["GET"]) #TODO: make this a POST
 def chat():
     message = flask.request.args.get("q")
     print("Sending message: ", message)
     send_message(message)
-    time.sleep(10) # TODO: there are about ten million ways to be smarter than this
     response = get_last_message()
     print("Response: ", response)
     return response
 
+# create a route for regenerating the response
+@APP.route("/regenerate", methods=["POST"])
+def regenerate():
+    print("Regenerating response")
+    if regenerate_response() is None:
+        return "No response to regenerate"
+    response = get_last_message()
+    print("Response: ", response)
+    return response
+
+@APP.route("/reset", methods=["POST"])
+def reset():
+    print("Resetting chat")
+    get_reset_button().click()
+    return "Chat thread reset"
+  
 def start_browser():
     PAGE.goto("https://chat.openai.com/")
     if not is_logged_in():


### PR DESCRIPTION
New endpoints: 
> /reset: resets the chat thread
> /regenerate: clicks on the Try again button to regenerate response

Also added logic to get the response as soon as it's done rendering (instead of sleeping 10s).

Documentation touchup to include new endpoints. 